### PR TITLE
Fix OCR worker paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>D2R Equipment Scoring</title>
-  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
   <style>
     body { font-family: Arial; background: #1e1e1e; color: #eee; padding: 2rem; }
     .container { display: flex; flex-direction: row; gap: 2rem; align-items: flex-start; }
@@ -180,6 +180,9 @@ document.getElementById("screenshot").addEventListener("change", function(event)
 
         Tesseract.recognize(dataURL, 'eng', {
           logger: m => console.log(m),
+          workerPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/worker.min.js',
+          corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/tesseract-core.wasm.js',
+          langPath: 'https://cdn.jsdelivr.net/npm/tesseract.js@5/lang-data',
           tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-% '
         }).then(({ data: { text } }) => {
           computeScore(text);


### PR DESCRIPTION
## Summary
- load Tesseract.js from version 5
- specify worker, core, and language paths to work when opened locally

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ad52525b88322a1046b41d8a8771b