### PR TITLE
Improve Tesseract worker setup and logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,18 +198,30 @@ document.getElementById("screenshot").addEventListener("change", function(event)
         document.getElementById("preview").src = dataURL;
 
         // OCR using a dedicated worker instead of the static recognize helper
-        const worker = await Tesseract.createWorker('eng+fra', 1, {
-          logger: m => console.log(m),
+        const worker = Tesseract.createWorker({
+          logger: m => {
+            console.log(m);
+            debugLog(m.status ? `${m.status} ${Math.round((m.progress || 0) * 100)}%` : JSON.stringify(m));
+          },
           corePath: 'https://cdn.jsdelivr.net/npm/tesseract.js-core@5/'
         });
-        await worker.setParameters({
-          tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-% '
-        });
-        const { data: { text } } = await worker.recognize(dataURL);
-        console.log(text);
-        debugLog('Raw OCR: ' + text);
-        computeScore(text);
-        await worker.terminate();
+
+        try {
+          await worker.load();
+          await worker.loadLanguage('eng+fra');
+          await worker.initialize('eng+fra');
+          await worker.setParameters({
+            tessedit_char_whitelist: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-% '
+          });
+          const { data: { text } } = await worker.recognize(dataURL);
+          debugLog('Raw OCR: ' + text);
+          computeScore(text);
+        } catch (err) {
+          console.error(err);
+          debugLog('OCR error: ' + err.message);
+        } finally {
+          await worker.terminate();
+        }
       };
       img.src = e.target.result;
     };


### PR DESCRIPTION
## Summary
- hook Tesseract logger to `debugLog`
- explicitly `load`, `loadLanguage`, and `initialize` the worker
- wrap OCR operations in try/catch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684af7cd10bc832291f4ff25049b8404