### PR TITLE
Fix regex in OCR cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,8 @@ function fixCommonOcrMistakes(text) {
     'DRAE': 'DROP'
   };
   for (let key in replacements) {
-    text = text.replace(new RegExp(key, 'g'), replacements[key]);
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    text = text.replace(new RegExp(escapedKey, 'g'), replacements[key]);
   }
   return text;
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,3 +2,14 @@ const fs = require('fs');
 const assert = require('assert');
 assert.ok(fs.existsSync('index.html'), 'index.html should exist');
 console.log('Basic check passed: index.html exists');
+
+// Verify fixCommonOcrMistakes handles special characters
+const html = fs.readFileSync('index.html', 'utf8');
+const start = html.indexOf('function fixCommonOcrMistakes');
+const end = html.indexOf('function extractValue', start);
+assert(start !== -1 && end !== -1, 'fixCommonOcrMistakes function not found');
+const fnText = html.slice(start, end);
+eval(fnText);
+const cleaned = fixCommonOcrMistakes('foo +1% bar');
+assert.ok(cleaned.includes('+10%'), 'should replace +1% with +10%');
+console.log('fixCommonOcrMistakes check passed');


### PR DESCRIPTION
## Summary
- escape regex special characters in `fixCommonOcrMistakes`
- add regression test for the OCR cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b08776e38832283b5b060992e73d7