### PR TITLE
Handle additional OCR mistakes

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,11 @@ function fixCommonOcrMistakes(text) {
     '+1%': '+10%',
     'RERTL': 'RIGHT',
     'CRLICK': 'CLICK',
-    'DRAE': 'DROP'
+    'DRAE': 'DROP',
+    'DAMACE': 'DAMAGE',
+    'SECKETED': 'SOCKETED',
+    'RE0UIRED': 'REQUIRED',
+    ' T ALL SKILLS': ' TO ALL SKILLS'
   };
   for (let key in replacements) {
     const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -120,12 +124,16 @@ function computeScore(rawText) {
   debugLog('Normalized text: ' + text);
   const stats = {
     leech: extractValue(text, /([0-9]+)%?\s*(?:LIFE\s*STOLEN(?:\s*PER\s*HIT)?|VOL\s*DE\s*VIE(?:\s*PAR\s*COUP)?)/),
-    res: [
-      extractValue(text, /(?:COLD\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*FROID)\s*\+?([0-9]+)/),
-      extractValue(text, /(?:LIGHTNING\s*RESIST(?:ANCE)?|RESISTANCE\s*A\s*LA\s*FOUDRE)\s*\+?([0-9]+)/),
-      extractValue(text, /(?:FIRE\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*FEU)\s*\+?([0-9]+)/),
-      extractValue(text, /(?:POISON\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*POISON)\s*\+?([0-9]+)/)
-    ].reduce((a, b) => a + b, 0),
+    res: (function() {
+      const indiv = [
+        extractValue(text, /(?:COLD\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*FROID)\s*\+?([0-9]+)/),
+        extractValue(text, /(?:LIGHTNING\s*RESIST(?:ANCE)?|RESISTANCE\s*A\s*LA\s*FOUDRE)\s*\+?([0-9]+)/),
+        extractValue(text, /(?:FIRE\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*FEU)\s*\+?([0-9]+)/),
+        extractValue(text, /(?:POISON\s*RESIST(?:ANCE)?|RESISTANCE\s*AU\s*POISON)\s*\+?([0-9]+)/)
+      ];
+      const allRes = extractValue(text, /ALL\s*RESIST(?:ANCE)?S?\s*\+?([0-9]+)/);
+      return indiv.reduce((a, b) => a + b, 0) + (allRes ? allRes * 4 : 0);
+    })(),
     dr: extractValue(text, /(?:DAMAGE\s*REDUCED\s*BY|DEGATS\s*REDUITS\s*DE)\s*([0-9]+)/),
     fcr: extractValue(text, /([0-9]+)%\s*(?:FASTER\s*CAST\s*RATE|VITESSE\s*DE\s*LANCEMENT)/),
     ias: extractValue(text, /([0-9]+)%\s*(?:INCREASED\s*ATTACK\s*SPEED|VITESSE\s*D?ATTAQUE\s*AUGMENTEE)/),

--- a/tests/test.js
+++ b/tests/test.js
@@ -12,4 +12,8 @@ const fnText = html.slice(start, end);
 eval(fnText);
 const cleaned = fixCommonOcrMistakes('foo +1% bar');
 assert.ok(cleaned.includes('+10%'), 'should replace +1% with +10%');
+const cleaned2 = fixCommonOcrMistakes('DAMACE REDUCED BY 15%');
+assert.ok(cleaned2.includes('DAMAGE'), 'should fix DAMACE spelling');
+const cleaned3 = fixCommonOcrMistakes('+1 T ALL SKILLS');
+assert.ok(cleaned3.includes(' TO ALL SKILLS'), 'should fix TO ALL SKILLS');
 console.log('fixCommonOcrMistakes check passed');


### PR DESCRIPTION
## Summary
- broaden text fixes for OCR errors like `DAMACE` and missing `O` in `TO ALL SKILLS`
- parse `ALL RESISTANCES` properly
- test new replacements in `fixCommonOcrMistakes`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0a3f698883229540c652ac1a6ba1