### PR TITLE
Fix clipboard and file upload handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,11 +408,13 @@ async function processImageBlob(blob) {
 }
 
 document.getElementById('screenshot').addEventListener('change', async function(event) {
-  const file = event.target.files[0];
-  if (file) {
-    debugLog('Image file selected, processing...');
-    await processImageBlob(file);
-  }
+  const input = event.target;
+  const file = input?.files?.[0];
+  if (!file) return;
+  // Reset immediately so selecting the same file twice still triggers processing
+  input.value = '';
+  debugLog('Image file selected, processing...');
+  await processImageBlob(file);
 });
 
 document.getElementById('archetype').addEventListener('change', () => {
@@ -427,26 +429,42 @@ document.getElementById('archetype').addEventListener('change', () => {
   computeScore(currentText);
 });
 
-document.addEventListener('paste', async event => {
+async function getImageBlobFromClipboardEvent(event) {
   const clipboardData = event.clipboardData || window.clipboardData;
-  if (!clipboardData) {
-    debugLog('Impossible de lire le presse-papiers.');
-    return;
+  if (clipboardData) {
+    const items = clipboardData.items && clipboardData.items.length
+      ? clipboardData.items
+      : clipboardData.files;
+    if (items && items.length) {
+      const imageItem = Array.from(items).find(item => item.type && item.type.startsWith('image/'));
+      if (imageItem) {
+        return imageItem.getAsFile ? imageItem.getAsFile() : imageItem;
+      }
+    }
   }
-  const items = clipboardData.items || clipboardData.files;
-  if (!items || !items.length) {
-    debugLog('Presse-papiers sans image détectée.');
-    return;
+  if (navigator.clipboard?.read) {
+    try {
+      const clipboardItems = await navigator.clipboard.read();
+      for (const item of clipboardItems) {
+        const imageType = item.types.find(type => type.startsWith('image/'));
+        if (!imageType) continue;
+        const blob = await item.getType(imageType);
+        if (blob) return blob;
+      }
+    } catch (err) {
+      debugLog("Lecture du presse-papiers refusée ou non supportée: " + err.message);
+    }
   }
-  const iterableItems = Array.from(items);
-  const imageItem = iterableItems.find(item => item.type && item.type.startsWith('image/'));
-  if (!imageItem) return;
-  event.preventDefault();
-  const blob = imageItem.getAsFile ? imageItem.getAsFile() : imageItem;
+  return null;
+}
+
+document.addEventListener('paste', async event => {
+  const blob = await getImageBlobFromClipboardEvent(event);
   if (!blob) {
-    debugLog("Impossible de récupérer l'image collée.");
+    debugLog('Aucune image détectée dans le presse-papiers.');
     return;
   }
+  event.preventDefault();
   debugLog('Image collée depuis le presse-papiers, traitement...');
   await processImageBlob(blob);
 });


### PR DESCRIPTION
## Summary
- allow re-uploading the same image file by resetting the chooser after processing
- improve clipboard image detection with a fallback to navigator.clipboard.read and clearer logging

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6936bc288322b8dca5400a6f56b5)